### PR TITLE
fix: Update text on login page

### DIFF
--- a/hpcaccess/templates/pages/login.html
+++ b/hpcaccess/templates/pages/login.html
@@ -9,19 +9,27 @@
     Welcome to <hb>HPC Access</hb>.
   </p>
   <p>
-    This web app allows <strong>principal investigators and group leaders</strong>
+  This website allows users of the <strong>BIH HPC cluster</strong> to
   </p>
   <ul>
-    <li>to bring their group to the cluster and create projects for collaboration on the cluster</li>
-    <li>onboard their group members onto the cluster</li>
-    <li>manage (add/remove) users in their groups and projects</li>
+    <li>display information about their main work group,</li>
+    <li>list the projects they are a member of,</li>
+    <li>and see quota utilisation for all storage locations they have access to.</li>
+  </ul>
+  <p>
+  Additionally <strong>principal investigators and group delegates</strong> can
+  <ul>
+    <li>start a new group on the BIH HPC cluster,</li>
+    <li>add new group members,</li>
+    <li>create projects with dedicated and collaborative storage resources,</li>
+    <li>and make requests for additional group/project resources.</li>
   </ul>
   <hr />
   <p>
-    Login with the user name and the &quot;email password&quot; of your home organization.
+    Please log in using your Charité or MDC account.
   </p>
   <p>
-    For example: <b>user@CHARITE</b> or <b>user@MDC-BERLIN</b>
+    Enter your user name as: <b>user@CHARITE</b> or <b>user@MDC-BERLIN</b>
   </p>
 
   <form class="form-signin" method="post" id="form-login">

--- a/hpcaccess/templates/pages/login.html
+++ b/hpcaccess/templates/pages/login.html
@@ -9,7 +9,7 @@
     Welcome to <hb>HPC Access</hb>.
   </p>
   <p>
-  This website allows users of the <strong>BIH HPC cluster</strong> to
+    This website allows users of the <strong>BIH HPC cluster</strong> to
   </p>
   <ul>
     <li>display information about their main work group,</li>
@@ -17,7 +17,7 @@
     <li>and see quota utilisation for all storage locations they have access to.</li>
   </ul>
   <p>
-  Additionally <strong>principal investigators and group delegates</strong> can
+    Additionally <strong>principal investigators and group delegates</strong> can
   <ul>
     <li>start a new group on the BIH HPC cluster,</li>
     <li>add new group members,</li>


### PR DESCRIPTION
closes #295 

Username/password text is now the same as on the SODAR login page.