### PR TITLE
fix: favicon url

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -53,7 +53,7 @@ urlpatterns = [
         ),
         name="admin-landing",
     ),
-    path("favicon.ico", RedirectView.as_view(url="/static/images/favicon.ico")),
+    path("favicon.ico", RedirectView.as_view(url="/static/images/favicons/favicon.ico")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 


### PR DESCRIPTION
Should fix the "broken internal link" warning.