### PR TITLE
chore: update version file via release-please

### DIFF
--- a/hpcaccess/__init__.py
+++ b/hpcaccess/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.0"  # x-release-please-version
 __version_info__ = tuple(
     [int(num) if num.isdigit() else num for num in __version__.replace("-", ".", 1).split(".")]
 )

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": ["hpcaccess/__init__.py"]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
This PR teaches release-please how to update the version in hpcaccess (because by default the python update logic looks for `project-name/__init__.py`, i.e., `hpc-access/__init__.py`, but we have `hpcaccess/__init__.py` without the hyphen)