### PR TITLE
chore: create pull requests for openapi schema changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,4 +140,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add src/hpc_access/openapi-schema.json
-          git diff --cached --quiet || git commit -m "chore: update OpenAPI schema [skip ci]" && git push
+          git diff --cached --quiet || git commit -m "chore: update OpenAPI schema [skip ci]"
+
+      - name: 'Create pull request'
+        uses: peter-evens/create-pull-request@v8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
+    env:
+      CELERY_BROKER_URL: redis://0.0.0.0:6379/0
+      DATABASE_URL: 'postgres://hpcaccess:hpcaccess@0.0.0.0/hpcaccess'
     steps:
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
Since the main branch is protected, the action cannot push to it directly.