### PR TITLE
feat: add view for aggregate storage across projects (#407)

### DIFF
--- a/src/adminsec/templates/adminsec/storage_by_hpc_group.html
+++ b/src/adminsec/templates/adminsec/storage_by_hpc_group.html
@@ -79,7 +79,7 @@
             },
             {
               extend: 'csvHtml5',
-              text: 'Export to CSV',
+              text: 'Export to TSV',
               fieldSeparator: '\t',
             },
             {

--- a/src/adminsec/templates/adminsec/storage_by_hpc_group.html
+++ b/src/adminsec/templates/adminsec/storage_by_hpc_group.html
@@ -5,11 +5,13 @@
 {% block css %}
   {{ block.super }}
   <link href="https://cdn.datatables.net/v/dt/dt-3.0.0/datatables.min.css" rel="stylesheet">
+  <link href="https://cdn.datatables.net/buttons/4.0.0/css/buttons.dataTables.min.css" rel="stylesheet">
 {% endblock css %}
 
 {% block javascript %}
   {{ block.super }}
   <script src="https://cdn.datatables.net/v/dt/dt-3.0.0/datatables.min.js" ></script>
+  <script src="https://cdn.datatables.net/buttons/4.0.0/js/dataTables.buttons.min.js" ></script>
 {% endblock javascript %}
 
 {% block content %}
@@ -62,7 +64,32 @@
   </table>
 
   <script>
-    const DT = new DataTable("#hpcaccess-storage-by-group");
+    const DT = new DataTable("#hpcaccess-storage-by-group", {
+      layout: {
+        topStart: 'pageLength',
+        topEnd: 'search',
+        bottomStart: 'info',
+        bottomEnd: 'paging',
+        bottom2: {
+          buttons: [
+            {
+              extend: 'copyHtml5',
+              text: 'Copy',
+              fieldSeparator: '\t',
+            },
+            {
+              extend: 'csvHtml5',
+              text: 'Export to CSV',
+              fieldSeparator: '\t',
+            },
+            {
+              extend: 'print',
+              text: 'Print'
+            },
+          ],
+        },
+      },
+    });
   </script>
 </div>
 {% endblock content %}

--- a/src/adminsec/templates/adminsec/storage_by_hpc_group.html
+++ b/src/adminsec/templates/adminsec/storage_by_hpc_group.html
@@ -1,0 +1,69 @@
+{% extends 'base.html' %}
+
+{% load common %}
+
+{% block css %}
+  {{ block.super }}
+  <link href="https://cdn.datatables.net/v/dt/dt-3.0.0/datatables.min.css" rel="stylesheet">
+{% endblock css %}
+
+{% block javascript %}
+  {{ block.super }}
+  <script src="https://cdn.datatables.net/v/dt/dt-3.0.0/datatables.min.js" ></script>
+{% endblock javascript %}
+
+{% block content %}
+<div class="container-fluid text-center">
+  <h2 class="mt-4">HPC Storage by Group</h2>
+
+  <table id="hpcaccess-storage-by-group" class="display" data-order='[[0, "asc"]]' data-page-length="50">
+    <caption>
+      This table shows the aggregate storage resources requested and used by each group. The values are the sum of the "normal" group storage and the combined storage used by all the projects of that group.
+    </caption>
+    <thead style="text-align: center;">
+      <tr>
+        <th class="dt-head-center" colspan="3" data-dt-order="disable"></th>
+        <th class="dt-head-center" colspan="2" data-dt-order="disable"><code>work [TiB]</code></th>
+        <th class="dt-head-center" colspan="2" data-dt-order="disable"><code>scratch [TiB]</code></th>
+        <th class="dt-head-center" colspan="2" data-dt-order="disable"><code>unmirrored [TiB]</code></th>
+        <th class="dt-head-center" colspan="2" data-dt-order="disable"><code>mirrored [TiB]</code></th>
+      </tr>
+      <tr>
+        <th>Group (gid)</th>
+        <th>Owner</th>
+        <th>Status</th>
+        <th>Requested</th>
+        <th>Used</th>
+        <th>Requested</th>
+        <th>Used</th>
+        <th>Requested</th>
+        <th>Used</th>
+        <th>Requested</th>
+        <th>Used</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for obj in object_list %}
+        <tr>
+          <td class="dt-body-left">{{ obj.name }} ({{ obj.gid }})</td>
+          <td class="dt-body-left">{{ obj.owner }}</td>
+          <td class="dt-body-left">{{ obj.status }}</td>
+          <td class="dt-body-right">{{ obj.resources_requested.tier1_work | floatformat }}</td>
+          <td class="dt-body-right">{{ obj.resources_used.tier1_work | floatformat }}</td>
+          <td class="dt-body-right">{{ obj.resources_requested.tier1_scratch | floatformat }}</td>
+          <td class="dt-body-right">{{ obj.resources_used.tier1_scratch | floatformat }}</td>
+          <td class="dt-body-right">{{ obj.resources_requested.tier2_unmirrored | floatformat }}</td>
+          <td class="dt-body-right">{{ obj.resources_used.tier2_unmirrored | floatformat }}</td>
+          <td class="dt-body-right">{{ obj.resources_requested.tier2_mirrored | floatformat }}</td>
+          <td class="dt-body-right">{{ obj.resources_used.tier2_mirrored | floatformat }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <script>
+    const DT = new DataTable("#hpcaccess-storage-by-group");
+  </script>
+</div>
+{% endblock content %}
+

--- a/src/adminsec/urls.py
+++ b/src/adminsec/urls.py
@@ -270,6 +270,14 @@ urlpatterns_ui = [
         view=views.TermsAndConditionsPublishView.as_view(),
         name="termsandconditions-publish",
     ),
+    # ------------------------------------------------------------------------------
+    # Storage related
+    # ------------------------------------------------------------------------------
+    path(
+        "storage/hpcgroup",
+        view=views.StorageByHpcGroupView.as_view(),
+        name="storage-hpcgroup",
+    ),
 ]
 
 urlpatterns_api = [

--- a/src/adminsec/views.py
+++ b/src/adminsec/views.py
@@ -27,6 +27,7 @@ from adminsec.constants import (
     DEFAULT_GROUP_DIRECTORY_TIER1_WORK,
     DEFAULT_GROUP_DIRECTORY_TIER2_MIRRORED,
     DEFAULT_GROUP_DIRECTORY_TIER2_UNMIRRORED,
+    DEFAULT_GROUP_RESOURCES,
     DEFAULT_HOME_DIRECTORY,
     DEFAULT_PROJECT_DIRECTORY_TIER1_SCRATCH,
     DEFAULT_PROJECT_DIRECTORY_TIER1_WORK,
@@ -1611,7 +1612,7 @@ class StorageByHpcGroupView(HpcPermissionMixin, ListView):
     model = HpcGroup
 
     def get_context_data(self, *args, **kwargs):
-        resource_keys = ["tier1_work", "tier1_scratch", "tier2_unmirrored", "tier2_mirrored"]
+        resource_keys = DEFAULT_GROUP_RESOURCES.keys()
         for obj in self.object_list:
             for k in resource_keys:
                 obj.resources_requested.setdefault(k, 0)

--- a/src/adminsec/views.py
+++ b/src/adminsec/views.py
@@ -1601,3 +1601,25 @@ class TermsAndConditionsPublishView(HpcPermissionMixin, FormMixin, View):
                 send_notification_user_consent(user)
 
         return HttpResponseRedirect(self.success_url)
+
+
+class StorageByHpcGroupView(HpcPermissionMixin, ListView):
+    """Storage by Hpc Group"""
+
+    permission_required = "adminsec.is_hpcadmin"
+    template_name = "adminsec/storage_by_hpc_group.html"
+    model = HpcGroup
+
+    def get_context_data(self, *args, **kwargs):
+        resource_keys = ["tier1_work", "tier1_scratch", "tier2_unmirrored", "tier2_mirrored"]
+        for obj in self.object_list:
+            for k in resource_keys:
+                obj.resources_requested.setdefault(k, 0)
+                obj.resources_used.setdefault(k, 0)
+            for project in HpcProject.objects.filter(group=obj):
+                for k in resource_keys:
+                    obj.resources_requested[k] += project.resources_requested.get(k, 0)
+                    obj.resources_used[k] += project.resources_used.get(k, 0)
+        ctx = super().get_context_data(*args, **kwargs)
+        ctx["object_list"] = self.object_list
+        return ctx

--- a/src/hpc_access/templates/pages/admin_landing.html
+++ b/src/hpc_access/templates/pages/admin_landing.html
@@ -16,6 +16,9 @@
     <a class="nav-link" href="{% url 'impersonate-search' %}">
       Impersonate &mdash; SEARCH
     </a>
+    <a class="nav-link" href="{% url 'adminsec:storage-hpcgroup' %}">
+      Group storage overview
+    </a>
   </nav>
 </div>
 {% endblock content %}


### PR DESCRIPTION
This PR addresses #407 by adding a view for the aggregate storage resources used by each group, which is the sum of the "normal" storage and the storage used by all their projects. The page is accessible from a link in the admin landing page.