### PR TITLE
chore: teach releaseplease to update version in uv.lock and openapi schema

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,19 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='hpc-access')].version"
+        },
+        {
+          "path": "src/hpc_access/openapi-schema.json",
+          "type": "toml",
+          "jsonpath": "$.info.version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/uv.lock
+++ b/uv.lock
@@ -1011,7 +1011,7 @@ wheels = [
 
 [[package]]
 name = "hpc-access"
-version = "0.1.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
With this PR, the hpc-access version should be updated by release-please also in uv.lock and src/hpc_access/openapi-schema.json.