### PR TITLE
fix: make User.description and .removed optional for now

### DIFF
--- a/src/hpc_access/openapi-schema.json
+++ b/src/hpc_access/openapi-schema.json
@@ -1435,7 +1435,8 @@
           },
           "description": {
             "type": "string",
-            "readOnly": true
+            "readOnly": true,
+            "nullable": true
           },
           "uid": {
             "type": "integer",
@@ -1458,7 +1459,8 @@
           },
           "removed": {
             "type": "boolean",
-            "readOnly": true
+            "readOnly": true,
+            "nullable": true
           },
           "current_version": {
             "type": "integer",
@@ -1940,7 +1942,8 @@
           },
           "description": {
             "type": "string",
-            "readOnly": true
+            "readOnly": true,
+            "nullable": true
           },
           "uid": {
             "type": "integer",
@@ -1963,7 +1966,8 @@
           },
           "removed": {
             "type": "boolean",
-            "readOnly": true
+            "readOnly": true,
+            "nullable": true
           },
           "current_version": {
             "type": "integer",

--- a/src/usersec/serializers.py
+++ b/src/usersec/serializers.py
@@ -92,7 +92,11 @@ class HpcUserAbstractSerializer(HpcObjectAbstractSerializer):
     resources_used = ResourceDataUserJSONField()
 
     status = serializers.ChoiceField(choices=Status.choices, read_only=True)
-    description = serializers.CharField(read_only=True)
+    description = serializers.CharField(
+        read_only=True,
+        required=False,
+        allow_null=True,
+    )
     uid = serializers.IntegerField(read_only=True)
     username = serializers.CharField(read_only=True)
     expiration = serializers.DateTimeField(read_only=True)
@@ -104,7 +108,11 @@ class HpcUserAbstractSerializer(HpcObjectAbstractSerializer):
     phone_number = serializers.SerializerMethodField()
     home_directory = serializers.CharField()
     login_shell = serializers.CharField()
-    removed = serializers.BooleanField(read_only=True)
+    removed = serializers.BooleanField(
+        read_only=True,
+        required=False,
+        allow_null=True,
+    )
 
     def get_email(self, obj) -> Optional[str]:
         return obj.user.email


### PR DESCRIPTION
... because the schema required these, even though removed isn't really used and description is set to "None" in hpc-access-cli.